### PR TITLE
Fix：LINE通知機能の実装

### DIFF
--- a/app/jobs/line_notifications_job.rb
+++ b/app/jobs/line_notifications_job.rb
@@ -6,25 +6,25 @@ class LineNotificationsJob < ApplicationJob
 
   # rubocop:disable Metrics/MethodLength
   def perform(*_args)
-    users = User.where(line_notification: true)
+    users = User.where(line_notification: true).includes(:line_authentication)
 
     users.each do |user|
-      @quiz = Quiz.get_notification_quiz(user)
+      quiz = Quiz.get_notification_quiz(user)
 
       message_text = <<~TEXT.chomp
         【今日のクイズ🌤】
 
-        #{@quiz.decorate.truncated_body}/
+        問題【#{quiz.decorate.truncated_body}/】
 
-          おはようございます！本日のクイズです！この読ませ押し、分かりますか？👀
+        おはようございます！本日のクイズです！この読ませ押し、分かりますか？👀
 
-          回答はコチラ💡
+        回答はコチラ💡
 
-          https://#{Settings.default_url_options.host}/quizzes/#{@quiz.id}/random_exam?openExternalBrowser=1
+        https://#{Settings.default_url_options.host}/quizzes/#{quiz.id}/random_exam?openExternalBrowser=1
       TEXT
 
       message = { type: 'text', text: message_text }
-      uid = user.authentications.find_by(provider: 'line').uid
+      uid = user.line_authentication.uid
       client.push_message(uid, message)
       logger.info 'PushLineSuccess'
     end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -14,5 +14,5 @@
 #  index_authentications_on_provider_and_uid  (provider,uid)
 #
 class Authentication < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, inverse_of: :line_authentication
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
-  has_one :line_authentication, -> { where(provider: 'line') }, class_name: 'Authentication'
+  has_one :line_authentication, -> { where(provider: 'line') },
+          class_name: 'Authentication', dependent: :destroy, inverse_of: :user
   accepts_nested_attributes_for :authentications
   has_many :bookmarks, dependent: :destroy
   has_many :bookmarked_quizzes, through: :bookmarks, source: :quiz

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
+  has_one :line_authentication, -> { where(provider: 'line') }, class_name: 'Authentication'
   accepts_nested_attributes_for :authentications
   has_many :bookmarks, dependent: :destroy
   has_many :bookmarked_quizzes, through: :bookmarks, source: :quiz

--- a/spec/jobs/line_notifications_job_spec.rb
+++ b/spec/jobs/line_notifications_job_spec.rb
@@ -4,45 +4,38 @@ RSpec.describe LineNotificationsJob, type: :job do
   include ActiveJob::TestHelper
 
   describe 'line_notification_job' do
-    context 'userのline_notificationがtrueの場合' do
-      let!(:user1) { create(:user, line_notification: true) }
-      let!(:user2) { create(:user, line_notification: false) }
-      let!(:user3) { create(:user, line_notification: true) }
-      let!(:quiz) { Quiz.find_by!(body: '問題1の問題文です') }
+    before do
+      allow(Quiz).to receive(:get_notification_quiz).and_return(quiz)
+      allow_any_instance_of(LineNotificationsJob).to receive(:client).and_return(line_client)
+    end
 
-      before do
-        allow(Quiz).to receive(:get_notification_quiz).and_return(quiz)
+    let!(:user1) { create(:user, line_notification: true) }
+    let!(:user2) { create(:user, line_notification: false) }
+    let!(:user3) { create(:user, line_notification: true) }
+    let!(:quiz) { Quiz.find_by!(body: '問題1の問題文です') }
+    let!(:line_client) { instance_double(Line::Bot::Client, push_message: double(:response, success?: true)) }
 
-        # Line::Bot::Clientのインスタンスをモックする
-        @line_client = instance_double(Line::Bot::Client)
-        allow(Line::Bot::Client).to receive(:new).and_return(@line_client)
+    it 'userのline_notificationがtrueの場合Line通知を送信する' do
 
-        # インスタンスメソッドに対してpush_messageをスタブ
-        allow(@line_client).to receive(:push_message).and_return(true)
-      end
-
-      it 'QuizのLine通知を送信すること' do
-        expected_text = <<~TEXT.chomp
+      expected_text = <<~TEXT.chomp
         【今日のクイズ🌤】
 
-        #{quiz.decorate.truncated_body}/
+        問題【#{quiz.decorate.truncated_body}/】
 
-          おはようございます！本日のクイズです！この読ませ押し、分かりますか？👀
+        おはようございます！本日のクイズです！この読ませ押し、分かりますか？👀
 
-          回答はコチラ💡
+        回答はコチラ💡
 
-          https://#{Settings.default_url_options.host}/quizzes/#{quiz.id}/random_exam?openExternalBrowser=1
-        TEXT
+        https://#{Settings.default_url_options.host}/quizzes/#{quiz.id}/random_exam?openExternalBrowser=1
+      TEXT
 
-        perform_enqueued_jobs do
-          LineNotificationsJob.perform_later
-        end
-
-        # @line_clientのインスタンスがpush_messageを呼び出しているか確認
-        expect(@line_client).to have_received(:push_message).with(user1.authentications.first.uid, { type: 'text', text: expected_text })
-        expect(@line_client).not_to have_received(:push_message).with(user2.authentications.first.uid, { type: 'text', text: expected_text })
-        expect(@line_client).to have_received(:push_message).with(user3.authentications.first.uid, { type: 'text', text: expected_text })
+      perform_enqueued_jobs do
+        LineNotificationsJob.perform_later
       end
+
+      expect(line_client).to have_received(:push_message).with(user1.line_authentication.uid, { type: 'text', text: expected_text })
+      expect(line_client).not_to have_received(:push_message).with(user2.line_authentication.uid, { type: 'text', text: expected_text })
+      expect(line_client).to have_received(:push_message).with(user3.line_authentication.uid, { type: 'text', text: expected_text })
     end
   end
 end

--- a/spec/requests/quizzes/bookmarked_exams_spec.rb
+++ b/spec/requests/quizzes/bookmarked_exams_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Quizzes::BookmarkedExams", type: :request do
       get quiz_bookmarked_exam_path(quiz1)
       expect(response).to have_http_status(:success)
       expect(session[:answered_bookmarked_quiz_ids]).to include quiz1.id
+      
       delete quizzes_bookmarked_exam_path
       expect(session[:answered_bookmarked_quiz_ids]).to be_empty
       expect(response).to redirect_to(root_path)

--- a/spec/requests/quizzes/random_exams_spec.rb
+++ b/spec/requests/quizzes/random_exams_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Quizzes::RandomExams", type: :request do
       get quiz_random_exam_path(quiz1)
       expect(response).to have_http_status(:success)
       expect(session[:answered_quiz_ids]).to include quiz1.id
+      
       delete quizzes_random_exam_path
       expect(session[:answered_quiz_ids]).to be_empty
       expect(response).to redirect_to(root_path)


### PR DESCRIPTION
## 実装内容概要
- LINE通知ジョブのコードを修正
  - AuthenticationモデルとN+1問題を起こしていたため解消
  - LINE uid取得のコードを短縮するためUserモデルにアソシエーション追加
  - 不要なインスタンス変数を削除
- ジョブのスペックのモックをシンプルにした

## 対象issue
#13 