### PR TITLE
Fix：「お気に入り」を「マイクイズ帳」に変更

### DIFF
--- a/app/controllers/quizzes/bookmarks_controller.rb
+++ b/app/controllers/quizzes/bookmarks_controller.rb
@@ -2,12 +2,12 @@ class Quizzes::BookmarksController < ApplicationController
   def create
     @quiz = Quiz.find(params[:quiz_id])
     current_user.bookmark(@quiz)
-    flash.now[:success] = 'お気に入りに追加しました'
+    flash.now[:success] = 'マイクイズ帳に追加しました'
   end
 
   def destroy
     @quiz = Quiz.find(params[:quiz_id])
     current_user.unbookmark(@quiz)
-    flash.now[:success] = 'お気に入りから解除しました'
+    flash.now[:success] = 'マイクイズ帳から削除しました'
   end
 end

--- a/app/views/quizzes/bookmarks/_bookmark_button.html.erb
+++ b/app/views/quizzes/bookmarks/_bookmark_button.html.erb
@@ -1,30 +1,32 @@
 <% if logged_in? %>
   <%= link_to quiz_bookmark_path(quiz), data: { turbo_method: 'post' }, class: 'btn-bookmark' do %>
     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-6 w-6"
-      fill="none"
+      width="24px"
+      height="24px"
       viewBox="0 0 24 24"
-      stroke="currentColor">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="#000000">
+      <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+      <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+      <g id="SVGRepo_iconCarrier">
+        <path d="M4 19V6.2C4 5.0799 4 4.51984 4.21799 4.09202C4.40973 3.71569 4.71569 3.40973 5.09202 3.21799C5.51984 3 6.0799 3 7.2 3H16.8C17.9201 3 18.4802 3 18.908 3.21799C19.2843 3.40973 19.5903 3.71569 19.782 4.09202C20 4.51984 20 5.0799 20 6.2V17H6C4.89543 17 4 17.8954 4 19ZM4 19C4 20.1046 4.89543 21 6 21H20M9 7H15M9 11H15M19 17V21" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+      </g>
     </svg>
   <% end %>
 <% else %>
   <svg
-    xmlns="http://www.w3.org/2000/svg"
-    class="h-6 w-6"
-    fill="none"
+    width="24px"
+    height="24px"
     viewBox="0 0 24 24"
-    stroke="currentColor"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="#000000"
     onclick="require_login_modal.showModal()">
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+    <g id="SVGRepo_iconCarrier">
+      <path d="M4 19V6.2C4 5.0799 4 4.51984 4.21799 4.09202C4.40973 3.71569 4.71569 3.40973 5.09202 3.21799C5.51984 3 6.0799 3 7.2 3H16.8C17.9201 3 18.4802 3 18.908 3.21799C19.2843 3.40973 19.5903 3.71569 19.782 4.09202C20 4.51984 20 5.0799 20 6.2V17H6C4.89543 17 4 17.8954 4 19ZM4 19C4 20.1046 4.89543 21 6 21H20M9 7H15M9 11H15M19 17V21" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+    </g>
   </svg>
 <% end %>

--- a/app/views/quizzes/bookmarks/_unbookmark_button.html.erb
+++ b/app/views/quizzes/bookmarks/_unbookmark_button.html.erb
@@ -1,14 +1,15 @@
 <%= link_to quiz_bookmark_path(quiz), data: { turbo_method: 'delete' }, class: 'btn-unbookmark' do %>
   <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-6 w-6"
-      fill="#ff0000"
-      viewBox="0 0 24 24"
-      stroke="#ff0000">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-    </svg>
+    width="24px"
+    height="24px"
+    viewBox="0 0 24 24"
+    fill="#ff8c00"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="#000000">
+    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+    <g id="SVGRepo_iconCarrier">
+      <path d="M4 19V6.2C4 5.0799 4 4.51984 4.21799 4.09202C4.40973 3.71569 4.71569 3.40973 5.09202 3.21799C5.51984 3 6.0799 3 7.2 3H16.8C17.9201 3 18.4802 3 18.908 3.21799C19.2843 3.40973 19.5903 3.71569 19.782 4.09202C20 4.51984 20 5.0799 20 6.2V17H6C4.89543 17 4 17.8954 4 19ZM4 19C4 20.1046 4.89543 21 6 21H20M9 7H15M9 11H15M19 17V21" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+    </g>
+  </svg>
 <% end %>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -17,7 +17,7 @@
           <th>問題</th>
           <th class="w-1/6">正解</th>
           <th class="w-1/12"><%= sort_link(@q, :category_name, 'ジャンル') %></th>
-          <th class="w-1/12"></th>
+          <th class="w-1/12">マイクイズ帳</th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/shared/_require_bookmark_modal.html.erb
+++ b/app/views/shared/_require_bookmark_modal.html.erb
@@ -2,15 +2,16 @@
   <div class="modal-box flex justify-center">
     <div>
       <h3 class="text-lg font-bold flex justify-center">
-        お気に入りクイズが無いようです！
+        マイクイズ帳が真っ白です…😢
       </h3>
       <p class="py-4 leading-relaxed">
-        お気に入り登録したクイズを出題することができます。<br>
+        マイクイズ帳からランダムで出題することができます。<br>
         ・苦手クイズ<br>
         ・記憶済クイズ etc...<br>
-        集中して学習したいクイズをお気に入り登録してみましょう。<br>
+        集中して学習したいクイズをマイクイズに追加してみましょう。<br>
       </p>
-      <div class="max-w-lg w-full">
+      <hr>
+      <div class="max-w-lg w-full mt-6">
         <%= link_to 'ランダム出題', quiz_random_exam_path(Quiz.get_random_quiz(session)), class: 'btn btn-primary w-full' %>
         <%= link_to 'クイズ一覧', quizzes_path, class: 'btn btn-primary w-full mt-3' %>
       </div>

--- a/app/views/shared/_require_login_modal.html.erb
+++ b/app/views/shared/_require_login_modal.html.erb
@@ -5,13 +5,14 @@
       <span class="font-bold underline decoration-green-500 decoration-4 underline-offset-0">
         LINE連携
       </span>
-        でベタ問をさらに強化！
+        で苦手問題を克服🤩
       </h3>
       <p class="py-4 leading-relaxed">
         LINE連携により以下の機能を利用できます。<br>
-        ・クイズのお気に入り登録<br>
-        ・お気に入りクイズからランダム出題<br>
-        ・クイズのデイリー通知<br>
+        <br>
+        ✅ 苦手クイズをマイクイズ帳に登録<br>
+        ✅ マイクイズ帳からランダム出題し集中練習<br>
+        ✅ クイズのデイリー通知<br>
       </p>
       <%= link_to auth_at_provider_path(provider: :line), class: 'btn btn-sm bg-green-500 text-white flex justify-center' do %>
         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" class="bi bi-line" viewBox="0 0 16 16">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -24,9 +24,11 @@
           <span class="font-bold underline decoration-sky-500 decoration-4 underline-offset-0">BetaMaster</span>は
           <span class="font-bold underline decoration-sky-500 decoration-4 underline-offset-0">ベタ問の「読ませ」</span>
           に特化したクイズ学習アプリです。<br>
-          ・問題文の一部だけを表示し、回答の確定ポイントを練習<br>
-          ・LINE連携で不得意問題の集中練習<br>
-          ・毎日のクイズ通知を受け取ることで継続した学習をサポート<br>
+          <br>
+          ✔ 問題文の一部だけを表示し、回答の確定ポイントを練習<br>
+          ✔ LINE連携で苦手問題の集中練習<br>
+          ✔ 毎日のクイズ通知を受け取ることで継続した学習をサポート<br>
+          <br>
           <span class="font-bold">さあ、共にベタ問を探求しましょう！</span>
         </p>
       </div>
@@ -39,12 +41,12 @@
       <div class="max-w-lg w-full mt-5">
       <% if logged_in? %>
         <% if current_user.bookmarked_quizzes.present? %>
-          <%= link_to 'お気に入りから出題', quiz_bookmarked_exam_path(Quiz.get_bookmarked_quiz(session, current_user)), class: 'btn btn-outline btn-primary w-full' %>
+          <%= link_to 'マイクイズ帳から出題', quiz_bookmarked_exam_path(Quiz.get_bookmarked_quiz(session, current_user)), class: 'btn btn-outline btn-primary w-full' %>
         <% else %>
-          <button class="btn btn-outline btn-primary w-full" onclick="require_bookmark_modal.showModal()">お気に入りから出題</button>
+          <button class="btn btn-outline btn-primary w-full" onclick="require_bookmark_modal.showModal()">マイクイズ帳から出題</button>
         <% end %>
       <% else %>
-        <button class="btn btn-outline btn-primary w-full" onclick="require_login_modal.showModal()">お気に入りから出題</button>
+        <button class="btn btn-outline btn-primary w-full" onclick="require_login_modal.showModal()">マイクイズ帳から出題</button>
       <% end %>
       </div>
     </div>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,6 @@
 default_url_options:
-  host: '394f-2400-2411-84e3-6500-453b-21b7-a16d-93b3.ngrok-free.app'
+  host: '152b-103-5-140-139.ngrok-free.app'
 line_callback_url: 
-  url: 'https://394f-2400-2411-84e3-6500-453b-21b7-a16d-93b3.ngrok-free.app/oauth/callback?provider=line'
+  url: 'https://152b-103-5-140-139.ngrok-free.app/oauth/callback?provider=line'
 redis:
   url: 'redis://redis:6379'


### PR DESCRIPTION
## 実装内容概要
- お気に入りアイコンを本マークに変更
- 「お気に入り」という文言を「マイクイズ帳」に変更
- モーダルの文言を微修正

## 対象issue
#16 

## テスト証跡
![bookmark_icon_test](https://github.com/user-attachments/assets/3a720ea3-6891-4fad-92ba-05e982b30083)
