### PR TITLE
Feature10 AWS ECSへのデプロイ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
-CMD ["bin/dev"]
+CMD ["sh", "-c", "if [ \"$SIDEKIQ_ENV\" = 'true' ]; then bundle exec sidekiq -C config/sidekiq.yml; else rails s -b 0.0.0.0; fi"]
+# CMD ["bin/dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,4 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
-CMD ["sh", "-c", "if [ \"$SIDEKIQ_ENV\" = 'true' ]; then bundle exec sidekiq -C config/sidekiq.yml; else rails s -b 0.0.0.0; fi"]
-# CMD ["bin/dev"]
+CMD ["sh", "-c", "if [ \"$SIDEKIQ_ENV\" = 'true' ]; then bundle exec sidekiq -C config/sidekiq.yml; elif [ \"$RAILS_ENV\" = 'production' ]; then rails s -b 0.0.0.0; else bin/dev; fi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG ROOT="/beta-master"
 ENV LANG=C.UTF-8
 ENV TZ=Asia/Tokyo
 
+RUN mkdir ${ROOT}
 WORKDIR ${ROOT}
 
 RUN apt-get update; \
@@ -23,6 +24,8 @@ RUN bundle install --jobs 4
 COPY package.json ${ROOT}
 COPY yarn.lock ${ROOT}
 RUN yarn install
+
+COPY . ${ROOT}
 
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,7 @@ services:
       - db
       - redis
       - chrome
+      - sidekiq
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -26,6 +27,20 @@ services:
       POSTGRES_PASSWORD: password
     volumes:
       - postgres_data:/var/lib/postgresql/data
+  sidekiq:
+    build: .
+    volumes:
+      - .:/beta-master:cached
+      - bundle:/usr/local/bundle
+      - node_modules:/beta-master/node_modules
+    depends_on:
+      - db
+      - redis
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      REDIS_URL: redis://redis:6379
+    command: bundle exec sidekiq -C config/sidekiq.yml
   redis:
     image: redis:latest
     ports:

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,8 @@ module BetaMaster
     end
 
     # Capybaraを利用したログインテスト用にRackSessionAccessを利用
-    config.middleware.use RackSessionAccess::Middleware
+    if Rails.env.test?
+      config.middleware.use RackSessionAccess::Middleware
+    end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,8 +19,8 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: db
-  username: <%= ENV["POSTGRES_USER"] %>
-  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { "password" } %>
 
 
 development:
@@ -85,4 +85,5 @@ production:
   <<: *default
   database: beta_master_production
   username: beta_master
+  host: <%= ENV["BETA_MASTER_DATABASE_HOST"] %>
   password: <%= ENV["BETA_MASTER_DATABASE_PASSWORD"] %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: Settings.redis.url }
+  config.redis = { url: ENV["REDIS_URL"] }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Settings.redis.url }
+  config.redis = { url: ENV["REDIS_URL"] }
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,5 +2,3 @@ default_url_options:
   host: 'f643-1-72-9-240.ngrok-free.app'
 line_callback_url: 
   url: 'https://f643-1-72-9-240.ngrok-free.app/oauth/callback?provider=line'
-redis:
-  url: 'redis://redis:6379'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,4 @@
 default_url_options:
-  host: 'xxxxxx'
+  host: 'beta-master.net'
 line_callback_url: 
-  url: 'https://xxxxxx/oauth/callback?provider=line'
+  url: 'https://beta-master.net/oauth/callback?provider=line'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,5 +2,3 @@ default_url_options:
   host: 'a4c1-220-147-214-245.ngrok-free.app'
 line_callback_url: 
   url: 'https://a4c1-220-147-214-245.ngrok-free.app/oauth/callback?provider=line'
-redis:
-  url: 'redis://redis:6379'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,12 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /myapp/tmp/pids/server.pid
 
+if [ "$RAILS_ENV" = "production" ]; then
+  bundle exec rails assets:precompile
+  # bundle exec rails db:create
+  # bundle exec rails db:migrate
+  # bundle exec rails db:seed
+fi
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,29 @@ module.exports = {
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',
     './app/assets/stylesheets/**/*.css',
-    './app/javascript/**/*.js'
+    './app/javascript/**/*.js',
+    './app/**/*.html.erb',
+    './app/views/**/*.erb'
+  ],
+  safelist: [
+    'bg-sky-100',
+    'bg-red-300',
+    'bg-yellow-300',
+    'bg-orange-300',
+    'bg-blue-300',
+    'bg-purple-300',
+    'bg-green-500',
+    'text-xs',
+    'badge',
+    'badge-outline',
+    'toast',
+    'toast-end',
+    'alert',
+    'alert-success',
+    'alert-error',
+    'alert-info',
+    'btn-bookmark',
+    'btn-unbookmark'
   ],
   plugins: [
     require('daisyui')
@@ -11,33 +33,5 @@ module.exports = {
   daisyui: {
     themes: ["light", "lemonade", "cupcake"],
     darkTheme: false,
-  },
-  purge: {
-    content: [
-      './app/**/*.html.erb',
-      './app/helpers/**/*.rb',
-      './app/javascript/**/*.js',
-      './app/views/**/*.erb',
-    ],
-    safelist: [
-      'bg-sky-100',
-      'bg-red-300',
-      'bg-yellow-300',
-      'bg-orange-300',
-      'bg-blue-300',
-      'bg-purple-300',
-      'bg-green-500',
-      'text-xs',
-      'badge',
-      'badge-outline',
-      'toast',
-      'toast-end',
-      'alert',
-      'alert-success',
-      'alert-error',
-      'alert-info',
-      'btn-bookmark',
-      'btn-unbookmark'
-    ],
-  },
+  }
 }


### PR DESCRIPTION
## 実装内容概要
- AWS環境を構築し、ECSへのデプロイを行った
  - VPCにてネットワーク環境構築
    - public1a
    - public1c
    - private1a
  - 本番環境のDBとしてRDSを作成
  - ECRへのイメージ登録 
  - ECSにてサービスのコンテナ立ち上げ
    - railsコンテナ(マルチAZ)
    - sidekiqコンテナ
  - Elasticacheをsidekiq用のredisとして作成
  - ALBにてrailsコンテナへの負荷分散
  - ACMでのHTTPS化強制
  - お名前ドットコムでのドメイン取得及びRoute53での名前解決

## 対象issue
#22 

## テスト証跡
![aws-deploy](https://github.com/user-attachments/assets/0d5b9432-93c3-4d25-8b4d-b9e983d82491)

