### PR TITLE
Fix：マイクイズ帳ランダム出題中にマイクイズ帳から解除するとContent Missingになる

### DIFF
--- a/app/controllers/quizzes/bookmarked_exams_controller.rb
+++ b/app/controllers/quizzes/bookmarked_exams_controller.rb
@@ -1,6 +1,7 @@
 class Quizzes::BookmarkedExamsController < ApplicationController
   before_action :require_login, only: %i[show destroy]
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def show
     session[:answered_bookmarked_quiz_ids] ||= []
 
@@ -20,6 +21,7 @@ class Quizzes::BookmarkedExamsController < ApplicationController
 
     @next_quiz = Quiz.get_bookmarked_quiz(session, current_user)
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def destroy
     session[:answered_bookmarked_quiz_ids] = []

--- a/app/controllers/quizzes/bookmarked_exams_controller.rb
+++ b/app/controllers/quizzes/bookmarked_exams_controller.rb
@@ -4,7 +4,18 @@ class Quizzes::BookmarkedExamsController < ApplicationController
   def show
     session[:answered_bookmarked_quiz_ids] ||= []
 
-    @quiz = current_user.bookmarked_quizzes.find(params[:quiz_id])
+    quiz = Quiz.find(params[:quiz_id])
+
+    if current_user.bookmark?(quiz)
+      @quiz = quiz
+    elsif current_user.bookmarked_quizzes.exists?
+      @quiz = Quiz.get_bookmarked_quiz(session, current_user)
+    else
+      flash[:error] = 'マイクイズ帳にクイズがありません！クイズを登録してください'
+      redirect_to quizzes_path
+      return
+    end
+
     session[:answered_bookmarked_quiz_ids] << @quiz.id
 
     @next_quiz = Quiz.get_bookmarked_quiz(session, current_user)

--- a/app/views/quizzes/bookmarked_exams/show.html.erb
+++ b/app/views/quizzes/bookmarked_exams/show.html.erb
@@ -5,7 +5,7 @@
     <div class="flex justify-between items-center space-x-2">
       <%= link_to '終了', quizzes_bookmarked_exam_path, data: { turbo_method: :delete, turbo_frame: '_top' },
                                                       class: 'inline-flex items-center justify-center whitespace-nowrap text-sm font-medium btn btn-outline flex-1' %>
-      <%= link_to '次の問題', quiz_bookmarked_exam_path(@next_quiz), data: { turbo_action: :advance },
+      <%= link_to '次の問題', quiz_bookmarked_exam_path(@next_quiz), data: { turbo_action: :advance, turbo_frame: '_top' },
                                                                  class: 'inline-flex items-center justify-center whitespace-nowrap text-sm font-medium btn btn-primary flex-1' %>
     </div>
   </div>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
 default_url_options:
-  host: 'f643-1-72-9-240.ngrok-free.app'
+  host: 'e00b-220-147-214-245.ngrok-free.app'
 line_callback_url: 
-  url: 'https://f643-1-72-9-240.ngrok-free.app/oauth/callback?provider=line'
+  url: 'https://e00b-220-147-214-245.ngrok-free.app/oauth/callback?provider=line'


### PR DESCRIPTION
## 実装内容概要
- quizzes/bookmarked_exam#show
  - ユーザーのマイクイズ帳登録を以下の状態に場合分けして処理を分けた
    - params[:id]のクイズを登録している場合 =>そのままクイズを表示する
    - params[:id]のクイズは登録されていないが他にマイクイズ帳にクイズは存在している =>新たにクイズを取得する
    - マイクイズ帳にクイズが存在しない =>クイズ一覧にリダイレクトさせる

## 対象issue
#25 

## テスト証跡
![bookmarked_exam_bug_fix](https://github.com/user-attachments/assets/a4a6e030-b4d2-4e8f-9f8a-689e9ede8f7c)

