### PR TITLE
Fix: sidekiqのダッシュボードにbasic認証を追加

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,13 @@
+require 'sidekiq/web'
+
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV["REDIS_URL"] }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV["REDIS_URL"] }
+end
+
+Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
+  [user, password] == [ENV.fetch('SIDEKIQ_ADMIN_BASIC_AUTH_USER') { 'sidekiq' }, ENV.fetch('SIDEKIQ_ADMIN_BASIC_AUTH_PASSWORD') { 'password' }]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,10 +22,8 @@ Rails.application.routes.draw do
     delete 'bookmarked_exam', to: 'bookmarked_exams#destroy'
   end
 
-  if Rails.env.development?
-    require 'sidekiq/web'
-    mount Sidekiq::Web, at: '/sidekiq'
-  end
+  require 'sidekiq/web'
+  mount Sidekiq::Web, at: '/sidekiq'
 
   namespace 'mypage' do
     root to: 'quizzes#index'


### PR DESCRIPTION
## 実装内容概要
- 本番環境で`/sidekiq`にアクセスした際に、sidekiqのダッシュボードにbasic認証でアクセスできるようにした
  - `routes.rb`にて`GET /sidekiq`のルーティングを開発環境に限定しないように変更
  - `initializers/sidekiq.rb`にBasic認証の設定を追加

## 対象issue
#27 

## テスト証跡
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/92b55480-26db-40d2-9dad-8b0764ff8d8c">

